### PR TITLE
Fix flaky unit test

### DIFF
--- a/lib/gen_batcher/partition.ex
+++ b/lib/gen_batcher/partition.ex
@@ -211,7 +211,7 @@ defmodule GenBatcher.Partition do
   defp schedule_next_flush(state) do
     # We use `:erlang.start_timer/3` to include the timer ref in the message.
     # This is important for handling race conditions from near-simultaneous
-    # flush conditions.
+    # flush triggers.
     :erlang.start_timer(state.batch_timeout, self(), :flush)
   end
 


### PR DESCRIPTION
## Purpose

The dynamic flush trigger test was flaky due to it's setup. It utilized the `start_and_seed_gen_batcher/1` helper to seed 3 items and trigger 2 flushes. The issue is that those flushes were triggered so close together that, occasionally, the second flush would trigger before the `TestBatcher` implementation could read the flush ref from the partition's process dictionary. This would cause the first flush to not be labelled "deferred", leading to a test failure.

## Approach

This PR eliminates the aforementioned race condition by waiting to insert the second and third items until the first flush occurs.

## Testing

The failing test was updated and reran multiple times locally without failure.

## Notes

Thankfully, this bug would not have occurred in production since the pdict usage is a hidden testing convenience, but this does highlight the potential dangers of using the pdict and the tricky errors that it can introduce. I stand by it's usage for this particular case, but I will definitely remember this bug as a cautionary tale.
