### PR TITLE
Cancel flush timer on shutdown

### DIFF
--- a/lib/gen_batcher/partition.ex
+++ b/lib/gen_batcher/partition.ex
@@ -189,7 +189,12 @@ defmodule GenBatcher.Partition do
   @impl GenServer
   @spec terminate(term(), State.t()) :: :ok
   def terminate(_, %State{items: [], flush_empty?: false}), do: :ok
-  def terminate(_, %State{} = state), do: do_blocking_flush(state)
+  def terminate(_, %State{timer: nil} = state), do: do_blocking_flush(state)
+
+  def terminate(_, %State{} = state) do
+    Process.cancel_timer(state.timer)
+    do_blocking_flush(state)
+  end
 
   ################################
   # Private API


### PR DESCRIPTION
Pretty obvious IMHO

Might be nice to test this though...

While we're on the subject, the janky conditional pdict update (and the existence of a flush ref TBH) should be reevaluated altogether (and we should consider doctests)

Am I trapping task exits? According to the docs, maybe I shouldn't be...
https://hexdocs.pm/elixir/Task.html#async/1-linking

Speaking of, using Task.async and then just skipping drop messages is probably better than turning the lone task supervisor into a bottleneck